### PR TITLE
updating link in readme to gh repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm -v
 3. Clone this repository and run the code locally against your New Relic data by running the following command:
 
 ```bash
-nr1 nerdpack:clone -r https://github.com/newrelic/nr1-nerdpack-layout-standard.git
+nr1 nerdpack:clone -r https://github.com/newrelic-experimental/nr1-innovation-cicd.git
 cd nr1-innovation-cicd
 nr1 nerdpack:serve
 ```
@@ -64,5 +64,5 @@ As noted in our [security policy](../../security/policy), New Relic is committed
 If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [HackerOne](https://hackerone.com/newrelic).
 
 ## License
-[Project Name] is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
->[If applicable: The [project name] also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.]
+nr1-innovation-cicd nerdpack is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
+>[If applicable: The nr1-innovation-cicd nerdpack also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.]


### PR DESCRIPTION
Tiny, (tiny) update to README to update the "how to use this" instructions with the correct link to this repo.
Also, updated references in the License portion of the README